### PR TITLE
Step2

### DIFF
--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -10,7 +10,6 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        ErrorResponse response =new ErrorResponse(HttpStatus.BAD_REQUEST, "에러가 발생했습니다.");
-        return ResponseEntity.status(response.code()).body(response);
+        return ResponseEntity.status(500).body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR,e.toString()));
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -57,6 +57,11 @@ public class PointService {
             if (existData.updateMillis() != 0) {
                 amount = existData.point() + amount;
             }
+
+            // insertOrUpdate(),insert()가 lock이 안걸려있기 때문에 재진입이 필요없는 것 같습니다.
+            // 그런데 이 메소드들을 또 따로 lock을 걸어놨어야했나라는 의문이 있습니다.
+            // 상위 메소드에서 하나의 락으로 관리해도 된다 vs 하위 메소드들도 따로 락을 생성해서 관리해야한다
+            // 이 둘 중 뭐가 맞을까요...?
             UserPoint result = userPointRepository.insertOrUpdate(id, amount);
             pointHistoryRepository.insert(id, amount, TransactionType.CHARGE, result.updateMillis());
 

--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -9,8 +9,10 @@ import io.hhplus.tdd.point.util.NoUserException;
 import io.hhplus.tdd.point.util.TransactionType;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 @Service
 public class PointService {
@@ -19,59 +21,92 @@ public class PointService {
 
     private final PointHistoryRepository pointHistoryRepository;
 
+//     재진입이 가능한 읽기-쓰기 락 구성
+//     재진입 : history update 시 락 재진입이 가능해야한다. -> 근데 현재 구현한건 재진입이 필요없는 것 같아서 괜히 했나 싶다...
+//     다수의 스레드가 읽기는 가능해야하지만 쓰기는 단일 스레드로만 수행하고자 한다.
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final Lock readLock = lock.readLock();
+    private final Lock writeLock = lock.writeLock();
+
     public PointService(UserPointRepository userPointRepository, PointHistoryRepository pointHistoryRepository) {
         this.userPointRepository = userPointRepository;
         this.pointHistoryRepository = pointHistoryRepository;
     }
 
     public UserPoint getPoint(long id) {
-        UserPoint result = userPointRepository.selectById(id);
-        // update한 시각이 없으므로 등록된 사용자가 아니다
-        if (result.updateMillis() == 0) {
-            throw new NoUserException();
+        readLock.lock();
+        try{
+            UserPoint result = userPointRepository.selectById(id);
+            // update한 시각이 없으므로 등록된 사용자가 아니다
+            if (result.updateMillis() == 0) {
+                throw new NoUserException();
+            }
+            return result;
+        }finally {
+            readLock.unlock();
         }
-        return result;
+
     }
 
     public UserPoint charge(long id, long amount) {
-        UserPoint existData = userPointRepository.selectById(id);
-        // 기존 사용자일 경우 기존에 있던 포인트와 합산
-        if (existData.updateMillis() != 0) {
-            amount = existData.point() + amount;
+        writeLock.lock();
+        try{
+            UserPoint existData = userPointRepository.selectById(id);
+            // 기존 사용자일 경우 기존에 있던 포인트와 합산
+            if (existData.updateMillis() != 0) {
+                amount = existData.point() + amount;
+            }
+            UserPoint result = userPointRepository.insertOrUpdate(id, amount);
+            pointHistoryRepository.insert(id, amount, TransactionType.CHARGE, result.updateMillis());
+
+            return result;
+        }finally {
+            writeLock.unlock();
         }
-        UserPoint result = userPointRepository.insertOrUpdate(id, amount);
-        pointHistoryRepository.insert(id, amount, TransactionType.CHARGE, result.updateMillis());
-        return result;
+
     }
 
     public UserPoint usePoint(long id, long amount) {
-        UserPoint existPoint = userPointRepository.selectById(id);
+        writeLock.lock();
+        try{
+            UserPoint existPoint = userPointRepository.selectById(id);
 
-        // 기존 사용자가 아닐 경우
-        if (existPoint.updateMillis() == 0) {
-            throw new NoUserException();
-        } else if (existPoint.point() - amount < 0) { // 포인트 부족시
-            throw new NoPointException();
+            // 기존 사용자가 아닐 경우
+            if (existPoint.updateMillis() == 0) {
+                throw new NoUserException();
+            } else if (existPoint.point() - amount < 0) { // 포인트 부족시
+                throw new NoPointException();
+            }
+            // 사용하고 남은 잔액 update
+            long newAmount = existPoint.point() - amount;
+            UserPoint result = userPointRepository.insertOrUpdate(id, newAmount);
+            // 사용한 이력 이력 table에 적재
+            pointHistoryRepository.insert(id, newAmount, TransactionType.USE, result.updateMillis());
+
+            // 새로운 포인트로 update 필요
+            return result;
+        }finally {
+            {
+                writeLock.unlock();
+            }
         }
-        // 사용하고 남은 잔액 update
-        long newAmount = existPoint.point() - amount;
-        UserPoint result = userPointRepository.insertOrUpdate(id, newAmount);
-        // 사용한 이력 이력 table에 적재
-        pointHistoryRepository.insert(id, newAmount, TransactionType.USE, result.updateMillis());
 
-        // 새로운 포인트로 update 필요
-        return result;
     }
 
     public List<PointHistory> history(long id) {
-        List<PointHistory> histories = new ArrayList<>();
+        readLock.lock();
+        try{
+            // 등록되어 있는 사용자인지 확인
+            UserPoint userPoint = userPointRepository.selectById(id);
+            if (userPoint.updateMillis() == 0) {
+                throw new NoUserException();
+            }
 
-        // 등록되어 있는 사용자인지 확인
-        UserPoint userPoint = userPointRepository.selectById(id);
-        if (userPoint.updateMillis() == 0) {
-            throw new NoUserException();
+            return pointHistoryRepository.selectAllByUserId(id);
+        }finally {
+            readLock.unlock();
         }
 
-        return pointHistoryRepository.selectAllByUserId(id);
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/controller/PointControllerTest.java
+++ b/src/test/java/io/hhplus/tdd/point/controller/PointControllerTest.java
@@ -160,7 +160,7 @@ class PointControllerTest {
                 .contentType(MediaType.APPLICATION_JSON));
 
         //then
-        resultActions.andExpect(status().isBadRequest())
+        resultActions.andExpect(status().isInternalServerError())
                 .andDo(print());
 
     }
@@ -182,7 +182,7 @@ class PointControllerTest {
                 .contentType(MediaType.APPLICATION_JSON));
 
         //then
-        resultActions.andExpect(status().isBadRequest())
+        resultActions.andExpect(status().isInternalServerError())
                 .andDo(print());
 
     }

--- a/src/test/java/io/hhplus/tdd/point/dto/UserPointTest.java
+++ b/src/test/java/io/hhplus/tdd/point/dto/UserPointTest.java
@@ -1,7 +1,0 @@
-package io.hhplus.tdd.point.dto;
-
-class UserPointTest {
-
-
-
-}

--- a/src/test/java/io/hhplus/tdd/point/service/ConcurrencyTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/ConcurrencyTest.java
@@ -1,0 +1,99 @@
+package io.hhplus.tdd.point.service;
+
+import io.hhplus.tdd.point.dto.UserPoint;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class ConcurrencyTest {
+
+    @Autowired
+    PointService pointService;
+
+
+    /**
+     * 동일 사용자가 여러번 요청을 보낼경우
+     * 순차적으로 처리하여
+     * 전제 조건 : 등록된 사용자여야 한다.
+     */
+    @DisplayName("한명의 사용자가 여러번 요청을 보낼 경우 ")
+    @Test
+    void oneUserMultiRequest() throws ExecutionException, InterruptedException {
+        // given : 사용자 포인트 100 등록
+        long userId = 1L;
+        pointService.charge(userId, 100);
+
+        // when
+        // 포인트 50 사용
+        CompletableFuture<UserPoint> resultActions1 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 50));
+        // 포인트 200 충전
+        CompletableFuture<UserPoint> resultActions2 = CompletableFuture.supplyAsync(() -> pointService.charge(userId, 200));
+        // 포인트 100 사용
+        CompletableFuture<UserPoint> resultActions3 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 100));
+        // 포인트 50 사용
+        CompletableFuture<UserPoint> resultActions4 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 50));
+        // 포인트 100 충전
+        CompletableFuture<UserPoint> resultActions5 = CompletableFuture.supplyAsync(() -> pointService.charge(userId, 100));
+
+        List<CompletableFuture<UserPoint>> futures = List.of(resultActions1, resultActions2, resultActions3, resultActions4, resultActions5);
+
+        CompletableFuture<List<UserPoint>> result = CompletableFuture.allOf(futures.toArray((new CompletableFuture[futures.size()])))
+                .thenApply(v -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+
+
+        //then
+        assertThat(pointService.getPoint(1).point()).isEqualTo(200);
+
+    }
+
+
+    /**
+     * 실행하고 난 다음에 이력을 잘 쌓고 있는지도 확인
+     * 포인트 사용 및 충전 이력을 순차적으로 잘 기록하는지 테스트
+      */
+
+    @DisplayName("포인트 사용/충전 이력을 순차적으로 잘 기록하는지 테스트 ")
+    @Test
+    void pointHistoryCheckTest() throws ExecutionException, InterruptedException {
+        // given : 사용자 포인트 100 등록
+        long userId = 1L;
+        pointService.charge(userId, 100);
+
+        long[] pointHistory = {50, 250, 150, 100, 200};
+
+        // when
+        // 포인트 50 사용
+        CompletableFuture<UserPoint> resultActions1 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 50));
+        // 포인트 200 충전
+        CompletableFuture<UserPoint> resultActions2 = CompletableFuture.supplyAsync(() -> pointService.charge(userId, 200));
+        // 포인트 100 사용
+        CompletableFuture<UserPoint> resultActions3 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 100));
+        // 포인트 50 사용
+        CompletableFuture<UserPoint> resultActions4 = CompletableFuture.supplyAsync(() -> pointService.usePoint(userId, 50));
+        // 포인트 100 충전
+        CompletableFuture<UserPoint> resultActions5 = CompletableFuture.supplyAsync(() -> pointService.charge(userId, 100));
+
+        List<CompletableFuture<UserPoint>> futures = List.of(resultActions1, resultActions2, resultActions3, resultActions4, resultActions5);
+
+        CompletableFuture<List<UserPoint>> result = CompletableFuture.allOf(futures.toArray((new CompletableFuture[futures.size()])))
+                .thenApply(v -> futures.stream().map(CompletableFuture::join).collect(Collectors.toList()));
+
+
+        //then
+        for (int i = 0; i < result.get().size(); i++) {
+            assertThat(result.get().get(i).point()).as("[point %d]", i).isEqualTo(pointHistory[i]);
+        }
+
+    }
+
+
+}

--- a/src/test/java/io/hhplus/tdd/point/service/ConcurrencyTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/ConcurrencyTest.java
@@ -1,6 +1,7 @@
 package io.hhplus.tdd.point.service;
 
 import io.hhplus.tdd.point.dto.UserPoint;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,6 @@ public class ConcurrencyTest {
     @Autowired
     PointService pointService;
 
-
     /**
      * 동일 사용자가 여러번 요청을 보낼경우
      * 순차적으로 처리하여
@@ -29,7 +29,7 @@ public class ConcurrencyTest {
     @Test
     void oneUserMultiRequest() throws ExecutionException, InterruptedException {
         // given : 사용자 포인트 100 등록
-        long userId = 1L;
+        long userId = 2L;
         pointService.charge(userId, 100);
 
         // when

--- a/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/PointServiceTest.java
@@ -82,7 +82,7 @@ class PointServiceTest {
         fakePointRepository.remove(userId);
 
         //when
-        UserPoint result = pointService.charge(userId, amount);
+        UserPoint result = pointService.charge(newUser, amount);
 
         //Then
         assertThat(result.id()).isEqualTo(expectedPoint.id());


### PR DESCRIPTION
# Step2 : 동시성처리
## 상세 기능

- 동시에 한 명의 사용자가 포인트 충전,이용을 할 경우 순차적으로 처리

### PoinService.java 
- Lock를 사용하여 순차적으로 처리

----
## 테스트 케이스
###  ConcurrencyTest
- 동시에 한 명의 사용자가 포인트 충전,이용을 할 경우 포인트가 정확히 계산되었는지 확인 
- 처리 이력이 순차적으로 저장되어있는지 확인 

---

## 코드 리뷰 포인트 
- ReentrantReadWriteLock을 이용해서 Lock을 구현했는데 이 클래스를 사용한게 조금은 의미가 없는 것 같아서 리뷰 부탁드립니다. 
- 의미가 없다 생각한 이유 : 현재 코드가 락 재진입이 필요가 없어서 굳이 재진입이 가능한 락을 사용했어야했는가라는 의문이 있습니다. 그런데 또 재진입이 필요가 없는지도 확실히 모르겠습니다. (하위 코드 참조)
- Lock 인터페이스에 다양한 클래스들이 있는데 현재 상황에서는 어떤 클래스를 사용하는것이 적합한가요?

[구현 코드 바로가기](https://github.com/JiheeOh/hhplus-tdd-java/blob/step2/src/main/java/io/hhplus/tdd/point/service/PointService.java)

[테스트 코드 바로가기](https://github.com/JiheeOh/hhplus-tdd-java/blob/step2/src/test/java/io/hhplus/tdd/point/service/ConcurrencyTest.java)

```java
   public UserPoint charge(long id, long amount) {
        writeLock.lock();
        try{
            UserPoint existData = userPointRepository.selectById(id);
            if (existData.updateMillis() != 0) {
                amount = existData.point() + amount;
            }
           // insertOrUpdate(),insert()가 lock이 안걸려있기 때문에 재진입이 필요없는 것 같습니다.
           // 그런데 한편으로는 이 메소드들을 또 따로 lock을 걸어놨어야했나라는 의문이 있습니다. 
           // 상위 메소드에서 하나의 락으로 관리한다 vs 하위 메소드들도 따로 락을 생성해서 재진입 허락해서 관리한다.
           // 이 둘 중 뭐가 나을까요...?
            UserPoint result = userPointRepository.insertOrUpdate(id, amount);
            pointHistoryRepository.insert(id, amount, TransactionType.CHARGE, result.updateMillis());

            return result;
        }finally {
            writeLock.unlock();
        }

    }
```

 